### PR TITLE
support default tcp framer/delimiter in order to make xetension to be…

### DIFF
--- a/src/main/scala/io/gatling/tcp/TcpProtocolBuilder.scala
+++ b/src/main/scala/io/gatling/tcp/TcpProtocolBuilder.scala
@@ -2,23 +2,21 @@ package io.gatling.tcp
 
 import java.nio.charset.Charset
 
-
 case object TcpProtocolBuilderAddressStep {
   def address(address: String) = TcpProtocolBuilderPortStep(address)
 }
 case class TcpProtocolBuilderPortStep(address: String) {
-  def port(port: Int) = TcpProtocolBuilderFramerStep(address, port)
+  def port(port: Int) = TcpProtocolBuilder(address, port, None)
 }
-case class TcpProtocolBuilderFramerStep(address: String, port: Int) {
-  def lengthBased(offset : Int, length: Int, adjust: Int, strip : Int) = {
-    TcpProtocolBuilder(address, port, LengthBasedTcpFramer(offset, length, adjust, strip))
+case class TcpProtocolBuilder(address: String, port: Int, framer: Option[TcpFramer]) {
+  def lengthBased(offset: Int, length: Int, adjust: Int, strip: Int) = {
+    TcpProtocolBuilder(address, port, Some(LengthBasedTcpFramer(offset, length, adjust, strip)))
   }
-  def lengthBased(length: Int):TcpProtocolBuilder = lengthBased(0, length, 0, length)
-  def delimiterBased(delimiters : String, strip : Boolean, charset : String = "UTF-8") = {
-    TcpProtocolBuilder(address,port, DelimiterBasedTcpFramer(delimiters.getBytes(Charset.forName(charset)),strip))
+  def lengthBased(length: Int): TcpProtocolBuilder = lengthBased(0, length, 0, length)
+  def delimiterBased(delimiters: String, strip: Boolean, charset: String = "UTF-8") = {
+    TcpProtocolBuilder(address, port, Some(DelimiterBasedTcpFramer(delimiters.getBytes(Charset.forName(charset)), strip)))
   }
-  def protobufVarint = TcpProtocolBuilder(address, port, ProtobufVarint32TcpFramer)
-}
-case class TcpProtocolBuilder(address: String, port: Int, framer : TcpFramer) {
-  def build() = new TcpProtocol(address = address, port = port, framer = framer)
+  def protobufVarint = TcpProtocolBuilder(address, port, Some(ProtobufVarint32TcpFramer))
+
+  def build() = new TcpProtocol(address = address, port = port, framer = framer getOrElse(LengthBasedTcpFramer(0, 4, 0, 4)))
 }

--- a/src/test/scala/TcpCompileTest.scala
+++ b/src/test/scala/TcpCompileTest.scala
@@ -7,6 +7,7 @@ import scala.concurrent.duration._
 class TcpCompile extends Simulation {
 
   val tcpConfig = tcp.address("127.0.0.1").port(4800).lengthBased(4)
+  val defaultFramerTcpConfig = tcp.address("127.0.0.1").port(4800)
   val scn = scenario("Tcp")
     .exec(tcp("Connect").connect())
     .pause(1)
@@ -18,6 +19,6 @@ class TcpCompile extends Simulation {
   }
     .exec(tcp("disconnect").disconnect())
 
-  setUp(scn.inject(atOnceUsers(5))).protocols(tcpConfig)
+  setUp(scn.inject(atOnceUsers(5))).protocols(defaultFramerTcpConfig, tcpConfig)
 
 }


### PR DESCRIPTION
… backward compatible with old scripts

Solving https://github.com/scalecube/gatling-tcp-extensions/issues/12