### PR TITLE
Added SSL / TLS support

### DIFF
--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -136,6 +136,6 @@ Now three types of delimiters is supported:
         .tls("TLSv1.2", "./certfile", "password")
 ```
 
-
+where ./certfile is the client certificate on the classpath
 
 

--- a/doc/Usage.md
+++ b/doc/Usage.md
@@ -125,3 +125,17 @@ Now three types of delimiters is supported:
 
   setUp(scn.inject(atOnceUsers(5))).protocols(tcpConfig)
 ```
+
+##Example with TLS
+
+```scala
+  val tcpConfig = tcp
+        .address("127.0.0.1")
+        .port(6000)
+        .delimiterBased(",", false, "UTF-8")
+        .tls("TLSv1.2", "./certfile", "password")
+```
+
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <properties>
+        <scala.version>2.11.4</scala.version>
+    </properties>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>GatlingTCP</artifactId>
+    <name>Gatling TCP Extensions</name>
+    <groupId>io.gatling.txp</groupId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-actor_2.11</artifactId>
+            <version>2.3.7</version>
+        </dependency>
+        <dependency>
+            <groupId>io.gatling</groupId>
+            <artifactId>gatling-core</artifactId>
+            <version>2.1.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.scala-logging</groupId>
+            <artifactId>scala-logging_2.11</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.gatling.highcharts</groupId>
+            <artifactId>gatling-charts-highcharts</artifactId>
+            <version>2.1.7</version>
+        </dependency>
+        <dependency>
+            <groupId>io.gatling</groupId>
+            <artifactId>gatling-test-framework</artifactId>
+            <version>2.1.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-testkit_2.11</artifactId>
+            <version>2.3.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scalamock</groupId>
+            <artifactId>scalamock-scalatest-support_2.11</artifactId>
+            <version>3.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_2.11</artifactId>
+            <version>2.2.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+            <version>3.10.1.Final</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scala.version>2.11.4</scala.version>
     </properties>
     <modelVersion>4.0.0</modelVersion>
@@ -22,7 +23,7 @@
         <dependency>
             <groupId>io.gatling</groupId>
             <artifactId>gatling-core</artifactId>
-            <version>2.1.7</version>
+            <version>2.1.5</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe.scala-logging</groupId>
@@ -37,12 +38,12 @@
         <dependency>
             <groupId>io.gatling.highcharts</groupId>
             <artifactId>gatling-charts-highcharts</artifactId>
-            <version>2.1.7</version>
+            <version>2.1.5</version>
         </dependency>
         <dependency>
             <groupId>io.gatling</groupId>
             <artifactId>gatling-test-framework</artifactId>
-            <version>2.1.7</version>
+            <version>2.1.5</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
@@ -67,10 +68,16 @@
             <artifactId>netty</artifactId>
             <version>3.10.1.Final</version>
         </dependency>
+
+
     </dependencies>
 
+
+
     <build>
+        <finalName>${project.artifactId}-${project.version}</finalName>
         <sourceDirectory>src/main/scala</sourceDirectory>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,4 +68,37 @@
             <version>3.10.1.Final</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/scala</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <args>
+                        <!-- work-around for https://issues.scala-lang.org/browse/SI-8358 -->
+                        <arg>-nobootcp</arg>
+                    </args>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,9 +8,10 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>GatlingTCP</artifactId>
     <name>Gatling TCP Extensions</name>
-    <groupId>io.gatling.txp</groupId>
+    <groupId>io.gatling.tcp</groupId>
     <version>1.0.0</version>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
+
 
     <dependencies>
         <dependency>

--- a/src/main/scala/io/gatling/tcp/TcpActor.scala
+++ b/src/main/scala/io/gatling/tcp/TcpActor.scala
@@ -109,8 +109,7 @@ class TcpActor(dataWriterClient : DataWriterClient) extends BaseActor {
       }
       case OnDisconnect(time) =>
         // disconnection triggered by server
-        logRequest(tx.session, tx.requestName, KO, tx.start, nowMillis, Some(s"Tcp connection closed by server"))
-        val newTx = tx.copy(updates = Session.MarkAsFailedUpdate :: tx.updates, check = None)
+        val newTx = tx.copy(updates = Session.Identity :: tx.updates, check = None)
         newTx.next ! newTx.applyUpdates(newTx.session).session
         context.stop(self)
 

--- a/src/main/scala/io/gatling/tcp/TcpEngine.scala
+++ b/src/main/scala/io/gatling/tcp/TcpEngine.scala
@@ -1,29 +1,31 @@
 package io.gatling.tcp
 
 import java.net.InetSocketAddress
-import java.util.concurrent.{ Executors, TimeUnit }
+import java.util.concurrent.{Executors, TimeUnit}
+import javax.net.ssl.SSLContext
 
 import akka.actor.ActorRef
 import com.typesafe.scalalogging.StrictLogging
 import io.gatling.core.akka.AkkaDefaults
-import io.gatling.core.check.Check
 import io.gatling.core.session.Session
 import io.gatling.tcp.check.TcpCheck
 import org.jboss.netty.bootstrap.ClientBootstrap
 import org.jboss.netty.buffer.{ChannelBuffer, ChannelBuffers}
 import org.jboss.netty.channel._
-import org.jboss.netty.channel.socket.nio.{ NioWorkerPool, NioClientBossPool, NioClientSocketChannelFactory }
-import org.jboss.netty.handler.codec.frame.{FrameDecoder, DelimiterBasedFrameDecoder, LengthFieldPrepender, LengthFieldBasedFrameDecoder}
+import org.jboss.netty.channel.socket.nio.{NioClientBossPool, NioClientSocketChannelFactory, NioWorkerPool}
+import org.jboss.netty.handler.codec.frame.{DelimiterBasedFrameDecoder, FrameDecoder, LengthFieldBasedFrameDecoder, LengthFieldPrepender}
 import org.jboss.netty.handler.codec.oneone.OneToOneEncoder
-import org.jboss.netty.handler.codec.protobuf.{ProtobufVarint32LengthFieldPrepender, ProtobufVarint32FrameDecoder}
-import org.jboss.netty.handler.codec.string.{ StringEncoder, StringDecoder }
-import org.jboss.netty.util.{ CharsetUtil, HashedWheelTimer }
+import org.jboss.netty.handler.codec.protobuf.{ProtobufVarint32FrameDecoder, ProtobufVarint32LengthFieldPrepender}
+import org.jboss.netty.handler.codec.string.{StringDecoder, StringEncoder}
+import org.jboss.netty.handler.ssl.SslHandler
+import org.jboss.netty.util.{CharsetUtil, HashedWheelTimer}
 
 import scala.concurrent.{Future, Promise}
-import scala.util.Try
 
 object TcpEngine extends AkkaDefaults with StrictLogging {
   private var _instance: Option[TcpEngine] = None
+
+  val NO_TLS = 0
 
   def start(): Unit = {
     if (!_instance.isDefined) {
@@ -42,9 +44,10 @@ object TcpEngine extends AkkaDefaults with StrictLogging {
 
   def instance: TcpEngine = _instance match {
     case Some(engine) => engine
-    case _            => throw new UnsupportedOperationException("Tcp engine hasn't been started")
+    case _ => throw new UnsupportedOperationException("Tcp engine hasn't been started")
   }
 }
+
 case class TcpTx(session: Session,
                  next: ActorRef,
                  start: Long,
@@ -58,14 +61,18 @@ case class TcpTx(session: Session,
     copy(session = newSession, updates = Nil)
   }
 }
+
 trait TcpFramer
+
 case class LengthBasedTcpFramer(lengthFieldOffset: Int, lengthFieldLength: Int,
-                                 lengthAdjustment: Int, bytesToStrip: Int) extends TcpFramer{
-  def this(lengthFieldLength: Int) = this(0,lengthFieldLength, 0,lengthFieldLength)
+                                lengthAdjustment: Int, bytesToStrip: Int) extends TcpFramer {
+  def this(lengthFieldLength: Int) = this(0, lengthFieldLength, 0, lengthFieldLength)
 }
-case class DelimiterBasedTcpFramer(delimiters : Array[Byte], stripDelimiter : Boolean) extends TcpFramer {
+
+case class DelimiterBasedTcpFramer(delimiters: Array[Byte], stripDelimiter: Boolean) extends TcpFramer {
   def this(delimiters: Array[Byte]) = this(delimiters, true)
 }
+
 case object ProtobufVarint32TcpFramer extends TcpFramer
 
 class TcpEngine {
@@ -78,13 +85,27 @@ class TcpEngine {
 
   val encoder: StringEncoder = new StringEncoder(CharsetUtil.UTF_8)
 
-  def tcpClient(session: Session, protocol: TcpProtocol, listener: MessageListener) : Future[Session] = {
+  //TODO Add TLS here
+  def tcpClient(session: Session, protocol: TcpProtocol, listener: MessageListener): Future[Session] = {
     val bootstrap = new ClientBootstrap(socketChannelFactory)
     bootstrap.setPipelineFactory(new ChannelPipelineFactory {
+
+      def getSSLHandler(): SslHandler = {
+        var context = SSLContext.getInstance("TLS")
+        context.init(null, null, null)
+        var engine = context.createSSLEngine()
+        engine.setUseClientMode(true)
+        new SslHandler(engine, false)
+      }
+
       override def getPipeline: ChannelPipeline = {
         val pipeline = Channels.pipeline()
         val framer = resolveFramer(protocol)
         val prepender = resolvePrepender(protocol)
+        if (protocol.tls > 0) {
+          val handler = getSSLHandler()
+          pipeline.addLast("ssl", handler)
+        }
         pipeline.addLast("framer", framer)
         pipeline.addLast("prepender", prepender)
         pipeline.addLast("decoder", stringDecoder)
@@ -101,7 +122,7 @@ class TcpEngine {
           val channel = channelFuture.getChannel
           session("channel").asOption[Channel] match {
             case Some(ch) => promise.trySuccess(session)
-            case None     => promise.trySuccess(session.set("channel", channel))
+            case None => promise.trySuccess(session.set("channel", channel))
           }
         } else {
           promise.failure(p1.getCause)
@@ -136,7 +157,7 @@ class TcpEngine {
     }
   }
 
-  def startTcpTransaction(tx: TcpTx, actor: ActorRef) : Unit = {
+  def startTcpTransaction(tx: TcpTx, actor: ActorRef): Unit = {
     val listener = new MessageListener(tx, actor)
     import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -144,7 +165,7 @@ class TcpEngine {
 
     client.onComplete {
       case scala.util.Success(session) => actor ! OnConnect(tx, session("channel").asOption[Channel].get, System.currentTimeMillis())
-      case scala.util.Failure(th) => actor ! OnConnectFailed(tx,System.currentTimeMillis())
+      case scala.util.Failure(th) => actor ! OnConnectFailed(tx, System.currentTimeMillis())
     }
   }
 }

--- a/src/main/scala/io/gatling/tcp/TcpProtocol.scala
+++ b/src/main/scala/io/gatling/tcp/TcpProtocol.scala
@@ -4,7 +4,7 @@ import io.gatling.core.config.Protocol
 import org.jboss.netty.handler.codec.frame.{LengthFieldBasedFrameDecoder, FrameDecoder}
 
 case class TcpProtocol(address: String,
-                       port: Int, framer : TcpFramer, tls: Int) extends Protocol {
+                       port: Int, framer : TcpFramer, tls: Option[TcpTls]) extends Protocol {
   override def warmUp(): Unit = {
     TcpEngine.start()
     super.warmUp()

--- a/src/main/scala/io/gatling/tcp/TcpProtocol.scala
+++ b/src/main/scala/io/gatling/tcp/TcpProtocol.scala
@@ -4,7 +4,7 @@ import io.gatling.core.config.Protocol
 import org.jboss.netty.handler.codec.frame.{LengthFieldBasedFrameDecoder, FrameDecoder}
 
 case class TcpProtocol(address: String,
-                       port: Int, framer : TcpFramer) extends Protocol {
+                       port: Int, framer : TcpFramer, tls: Int) extends Protocol {
   override def warmUp(): Unit = {
     TcpEngine.start()
     super.warmUp()

--- a/src/main/scala/io/gatling/tcp/TcpProtocolBuilder.scala
+++ b/src/main/scala/io/gatling/tcp/TcpProtocolBuilder.scala
@@ -6,17 +6,18 @@ case object TcpProtocolBuilderAddressStep {
   def address(address: String) = TcpProtocolBuilderPortStep(address)
 }
 case class TcpProtocolBuilderPortStep(address: String) {
-  def port(port: Int) = TcpProtocolBuilder(address, port, None)
+  def port(port: Int) = TcpProtocolBuilder(address, port, None, 0)
 }
-case class TcpProtocolBuilder(address: String, port: Int, framer: Option[TcpFramer]) {
-  def lengthBased(offset: Int, length: Int, adjust: Int, strip: Int) = {
-    TcpProtocolBuilder(address, port, Some(LengthBasedTcpFramer(offset, length, adjust, strip)))
+// TODO Add TLS as an option here
+case class TcpProtocolBuilder(address: String, port: Int, framer: Option[TcpFramer], tls: Int) {
+  def lengthBased(offset: Int, length: Int, adjust: Int, strip: Int, tls: Int) = {
+    TcpProtocolBuilder(address, port, Some(LengthBasedTcpFramer(offset, length, adjust, strip)), tls)
   }
-  def lengthBased(length: Int): TcpProtocolBuilder = lengthBased(0, length, 0, length)
-  def delimiterBased(delimiters: String, strip: Boolean, charset: String = "UTF-8") = {
-    TcpProtocolBuilder(address, port, Some(DelimiterBasedTcpFramer(delimiters.getBytes(Charset.forName(charset)), strip)))
+  def lengthBased(length: Int, tls: Int): TcpProtocolBuilder = lengthBased(0, length, 0, length, tls)
+  def delimiterBased(delimiters: String, strip: Boolean, charset: String = "UTF-8", tls: Int) = {
+    TcpProtocolBuilder(address, port, Some(DelimiterBasedTcpFramer(delimiters.getBytes(Charset.forName(charset)), strip)), tls)
   }
-  def protobufVarint = TcpProtocolBuilder(address, port, Some(ProtobufVarint32TcpFramer))
+  def protobufVarint = TcpProtocolBuilder(address, port, Some(ProtobufVarint32TcpFramer), 0)
 
-  def build() = new TcpProtocol(address = address, port = port, framer = framer getOrElse(LengthBasedTcpFramer(0, 4, 0, 4)))
+  def build() = new TcpProtocol(address = address, port = port, framer = framer getOrElse(LengthBasedTcpFramer(0, 4, 0, 4)), tls = tls)
 }

--- a/src/main/scala/io/gatling/tcp/TcpProtocolBuilder.scala
+++ b/src/main/scala/io/gatling/tcp/TcpProtocolBuilder.scala
@@ -6,18 +6,27 @@ case object TcpProtocolBuilderAddressStep {
   def address(address: String) = TcpProtocolBuilderPortStep(address)
 }
 case class TcpProtocolBuilderPortStep(address: String) {
-  def port(port: Int) = TcpProtocolBuilder(address, port, None, 0)
+  def port(port: Int) = TcpProtocolBuilder(address, port, None, None)
 }
-// TODO Add TLS as an option here
-case class TcpProtocolBuilder(address: String, port: Int, framer: Option[TcpFramer], tls: Int) {
-  def lengthBased(offset: Int, length: Int, adjust: Int, strip: Int, tls: Int) = {
-    TcpProtocolBuilder(address, port, Some(LengthBasedTcpFramer(offset, length, adjust, strip)), tls)
-  }
-  def lengthBased(length: Int, tls: Int): TcpProtocolBuilder = lengthBased(0, length, 0, length, tls)
-  def delimiterBased(delimiters: String, strip: Boolean, charset: String = "UTF-8", tls: Int) = {
-    TcpProtocolBuilder(address, port, Some(DelimiterBasedTcpFramer(delimiters.getBytes(Charset.forName(charset)), strip)), tls)
-  }
-  def protobufVarint = TcpProtocolBuilder(address, port, Some(ProtobufVarint32TcpFramer), 0)
 
-  def build() = new TcpProtocol(address = address, port = port, framer = framer getOrElse(LengthBasedTcpFramer(0, 4, 0, 4)), tls = tls)
+case class TcpTls(ver: String, trustStoreResource: String, password: String) {
+
+}
+
+
+
+// TODO Add TLS as an option here
+case class TcpProtocolBuilder(address: String, port: Int, framer: Option[TcpFramer], tlsLayer: Option[TcpTls]) {
+  def lengthBased(offset: Int, length: Int, adjust: Int, strip: Int) = {
+    TcpProtocolBuilder(address, port, Some(LengthBasedTcpFramer(offset, length, adjust, strip)), tlsLayer)
+  }
+  def lengthBased(length: Int): TcpProtocolBuilder = lengthBased(0, length, 0, length)
+  def delimiterBased(delimiters: String, strip: Boolean, charset: String = "UTF-8") = {
+    TcpProtocolBuilder(address, port, Some(DelimiterBasedTcpFramer(delimiters.getBytes(Charset.forName(charset)), strip)), tlsLayer)
+  }
+  def protobufVarint = TcpProtocolBuilder(address, port, Some(ProtobufVarint32TcpFramer), tlsLayer)
+
+  def tls(ver: String, trustStoreResource: String, password: String) = TcpProtocolBuilder(address, port, framer, Some(TcpTls(ver, trustStoreResource, password)))
+
+  def build() = new TcpProtocol(address = address, port = port, framer = framer getOrElse(LengthBasedTcpFramer(0, 4, 0, 4)), tls = tlsLayer)
 }

--- a/src/test/scala/TcpActorSpec.scala
+++ b/src/test/scala/TcpActorSpec.scala
@@ -11,7 +11,7 @@ import io.gatling.tcp.check.TcpCheck
 import org.jboss.netty.channel.Channel
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpecLike}
-
+import io.gatling.tcp.TcpEngine._
 import scala.concurrent.duration._
 
 class TcpActorSpec(_system: ActorSystem) extends TestKit(_system) with WordSpecLike with Matchers with BeforeAndAfterAll
@@ -19,7 +19,7 @@ with MockFactory {
 
   def this() = this(GatlingActorSystem.start())
 
-  val protocol = tcp.address("127.0.0.1").port(4800).lengthBased(4)
+  val protocol = tcp.address("127.0.0.1").port(4800).lengthBased(4, NO_TLS)
   val dataWriterClient = new TestDataWriterClient()
 
   GatlingConfiguration.setUpForTest()

--- a/src/test/scala/TcpActorSpec.scala
+++ b/src/test/scala/TcpActorSpec.scala
@@ -19,7 +19,7 @@ with MockFactory {
 
   def this() = this(GatlingActorSystem.start())
 
-  val protocol = tcp.address("127.0.0.1").port(4800).lengthBased(4, NO_TLS)
+  val protocol = tcp.address("127.0.0.1").port(4800).lengthBased(4)
   val dataWriterClient = new TestDataWriterClient()
 
   GatlingConfiguration.setUpForTest()

--- a/src/test/scala/TcpCompileTest.scala
+++ b/src/test/scala/TcpCompileTest.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
 
 class TcpCompile extends Simulation {
 
-  val tcpConfig = tcp.address("127.0.0.1").port(4800).lengthBased(4, NO_TLS)
+  val tcpConfig = tcp.address("127.0.0.1").port(4800).lengthBased(4)
   val defaultFramerTcpConfig = tcp.address("127.0.0.1").port(4800)
   val scn = scenario("Tcp")
     .exec(tcp("Connect").connect())

--- a/src/test/scala/TcpCompileTest.scala
+++ b/src/test/scala/TcpCompileTest.scala
@@ -1,12 +1,14 @@
 import io.gatling.core.Predef._
 import io.gatling.core.scenario.Simulation
 import io.gatling.tcp.Predef._
+import io.gatling.tcp.TcpEngine._
+
 
 import scala.concurrent.duration._
 
 class TcpCompile extends Simulation {
 
-  val tcpConfig = tcp.address("127.0.0.1").port(4800).lengthBased(4)
+  val tcpConfig = tcp.address("127.0.0.1").port(4800).lengthBased(4, NO_TLS)
   val defaultFramerTcpConfig = tcp.address("127.0.0.1").port(4800)
   val scn = scenario("Tcp")
     .exec(tcp("Connect").connect())

--- a/src/test/scala/io/gatling/tcp/TcpEngineTest.scala
+++ b/src/test/scala/io/gatling/tcp/TcpEngineTest.scala
@@ -1,0 +1,44 @@
+package io.gatling.tcp
+
+import akka.actor.ActorRef
+import io.gatling.core.result.writer.DataWriterClient
+import io.gatling.core.session.Session
+import io.gatling.core.util.TimeHelper
+import org.jboss.netty.bootstrap.ClientBootstrap
+import org.jboss.netty.channel.{Channel, ChannelFuture, ChannelFutureListener, Channels}
+import org.scalamock.FunctionAdapter1
+import org.scalatest._
+import org.scalamock.scalatest._
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+/**
+  * Created by stefancompton on 22/08/2018.
+  */
+class TcpEngineTest extends FlatSpec with MockFactory {
+
+  val mockChannelFuture = stub[ChannelFuture]
+  val mockChannel = mock[Channel]
+
+  (mockChannelFuture.isSuccess _) when() returns(true)
+  (mockChannelFuture.getChannel _) when() returns(mockChannel)
+
+  val tcpEngine = new TcpEngine()
+  val session = Session("SessionName", "SessionID")
+  val bootstrap = new ClientBootstrap(tcpEngine.socketChannelFactory)
+
+  val tcpMessage = TextTcpMessage("Message")
+  val tcpProtocol = TcpProtocol("localhost", 0, DelimiterBasedTcpFramer(Array(' '), false), Some(TcpTls("TLSv1.2", "abc", "abc")))
+  val tcpTx = TcpTx(session, ActorRef.noSender, TimeHelper.nowMillis, tcpProtocol, tcpMessage, "ReqName")
+  val listener = new MessageListener(tcpTx, ActorRef.noSender)
+
+  "A TCP TLS Connection" should "Have an SSL attribute" in {
+
+    val result = tcpEngine.tcpClient(session, tcpProtocol, listener, mockChannelFuture, bootstrap)
+    assert (result.isInstanceOf[Future[Session]])
+    val pipeline = bootstrap.getPipelineFactory.getPipeline
+    assert(pipeline.getNames.contains("ssl"))
+  }
+
+}


### PR DESCRIPTION
Hoping to address #18 

We added TLS / SSL support - you just need to point to certificates on the CP of any importing project.

We moved to Maven to build the project as SBT does not work inside our firewall - SBT should still work and build as we have not added any dependencies.

We had to change the Gatling version from 2.1.7 to 2.1.5 for compatibility with an internal project, but again tis shouldn't have any adverse impact.

We added a short example of how the tcp method works to usage.md

We also had to fix an error that occurs when the server closes the connection, as this is correct behaviour for the service we are testing.

We added a unit test to confirm the TLS data is correctly passed - more extensive testing might require significant rework
